### PR TITLE
AssetViewHelpers use Page Template Setup

### DIFF
--- a/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
+++ b/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
@@ -84,7 +84,7 @@ abstract class AbstractAssetViewHelper extends AbstractTagBasedViewHelper
     /**
      * Add the resource to the template setup according to the given position
      * 
-     * @param $position
+     * @param string $position
      */
     protected function addResourceToPageTemplateSetup($position)
     {

--- a/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
+++ b/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
@@ -76,6 +76,18 @@ abstract class AbstractAssetViewHelper extends AbstractTagBasedViewHelper
         }
 
         $position = $this->arguments['position'] ?: $this->defaultTagPosition;
+        $this->addResourceToPageTemplateSetup($position);
+
+        $GLOBALS['SCRIPT_STYPE_PUSH_ASSETS'][] = $this->arguments['name'];
+    }
+
+    /**
+     * Add the resource to the template setup according to the given position
+     * 
+     * @param $position
+     */
+    protected function addResourceToPageTemplateSetup($position)
+    {
         $key = $this->getTemplateSetupKeyForPosition($position) . '.';
 
         // Modify page template setup
@@ -91,8 +103,6 @@ abstract class AbstractAssetViewHelper extends AbstractTagBasedViewHelper
         if (count($resource) > 1) {
             $setup[$key][$resourceIndex . '.'] = $resource[1];
         }
-
-        $GLOBALS['SCRIPT_STYPE_PUSH_ASSETS'][] = $this->arguments['name'];
     }
 
     /**

--- a/Classes/ViewHelpers/Asset/ScriptViewHelper.php
+++ b/Classes/ViewHelpers/Asset/ScriptViewHelper.php
@@ -43,27 +43,35 @@ class ScriptViewHelper extends AbstractAssetViewHelper
     public function initializeArguments()
     {
         parent::initializeArguments();
-        $this->registerArgument('async', 'boolean', '', false, false);
+        $this->registerArgument('async', 'boolean', 'Allows the file to be loaded asynchronously', false, false);
+        $this->registerArgument('type', 'boolean', 'Setting the MIME type of the script (default: text/javascript)', false, null);
+        $this->registerArgument('integrity', 'boolean', 'Adds the integrity attribute to the script element to let browsers ensure subresource integrity. Useful in hosting scenarios with resources externalized to CDN\'s. See SRI for more details. Integrity hashes may be generated using https://srihash.org/', false, false);
     }
 
     /**
-     * @param string $filePath
-     * @return string
+     * {@inheritdoc}
      */
-    protected function buildTag($filePath)
+    protected function buildResourceInformation()
     {
-        $this->tag->reset();
-        $this->tag->setTagName('script');
-        $this->tag->forceClosingTag(true);
+        $resource = parent::buildResourceInformation();
 
-        // Build the tag.
-        $this->tag->addAttribute('src', $filePath);
-        $this->tag->addAttribute('type', 'text/javascript');
+        $resource[1]['async'] = $this->arguments['async'];
+        $resource[1]['integrity'] = $this->arguments['integrity'];
 
-        if ($this->arguments['async'] === true) {
-            $this->tag->addAttribute('async', 'async');
+        if ($this->arguments['type']) {
+            $resource[1]['type'] = $this->arguments['type'];
         }
 
-        return $this->tag->render();
+        return $resource;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @link https://docs.typo3.org/typo3cms/TyposcriptReference/8.7/Setup/Page/
+     */
+    public function getTemplateSetupKeyForPosition(string $position)
+    {
+        return $position == 'header' ? 'includeJS' : 'includeJSFooter';
     }
 }

--- a/Classes/ViewHelpers/Asset/StyleViewHelper.php
+++ b/Classes/ViewHelpers/Asset/StyleViewHelper.php
@@ -39,28 +39,42 @@ class StyleViewHelper extends AbstractAssetViewHelper
     {
         parent::initializeArguments();
 
-        $this->registerArgument('media', 'string', '', false);
+        $this->registerArgument('alternate', 'boolean', 'If set then the rel-attribute will be "alternate stylesheet', false, false);
+        $this->registerArgument('import', 'boolean', 'If set then the @import way of including a stylesheet is used instead of <link>', false, false);
+        $this->registerArgument('inline', 'boolean', 'If set, the content of the CSS file is inlined using <style> tags. Note that external files are not inlined', false, false);
+        $this->registerArgument('media', 'string', 'Setting the media attribute of the <style> tag', false);
+        $this->registerArgument('title', 'string', 'Setting the title of the <style> tag', false);
     }
 
     /**
-     * @param string $filePath
-     * @return string
+     * {@inheritdoc}
      */
-    protected function buildTag($filePath)
+    protected function buildResourceInformation()
     {
-        $this->tag->reset();
-        $this->tag->setTagName('link');
-        $this->tag->forceClosingTag(false);
+        $resource = parent::buildResourceInformation();
 
-        // Build the tag.
-        $this->tag->addAttribute('href', $filePath);
-        $this->tag->addAttribute('type', 'text/css');
-        $this->tag->addAttribute('rel', 'stylesheet');
+        $resource[1]['alternate'] = $this->arguments['alternate'];
+        $resource[1]['import'] = $this->arguments['import'];
+        $resource[1]['inline'] = $this->arguments['inline'];
 
         if ($this->arguments['media']) {
-            $this->tag->addAttribute('media', $this->arguments['media']);
+            $resource[1]['media'] = $this->arguments['media'];
         }
 
-        return $this->tag->render();
+        if ($this->arguments['title']) {
+            $resource[1]['title'] = $this->arguments['title'];
+        }
+
+        return $resource;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @link https://docs.typo3.org/typo3cms/TyposcriptReference/8.7/Setup/Page/
+     */
+    public function getTemplateSetupKeyForPosition(string $position)
+    {
+        return 'includeCSS';
     }
 }

--- a/Classes/ViewHelpers/Asset/StyleViewHelper.php
+++ b/Classes/ViewHelpers/Asset/StyleViewHelper.php
@@ -69,7 +69,8 @@ class StyleViewHelper extends AbstractAssetViewHelper
     }
 
     /**
-     * {@inheritdoc}
+     * Returns the key in the page setup where these resources should be added to.
+     * Always return "includeCSS" because the page renderer only supports this position for CSS files yet.
      *
      * @link https://docs.typo3.org/typo3cms/TyposcriptReference/8.7/Setup/Page/
      */


### PR DESCRIPTION
Both `StyleViewHelper` and `ScriptViewHelper` add their assets to the page template setup (CObject = `PAGE` for current `typeNum`) into `includeCSS`, `includeJS` or `includeJSFooter`.