### PR TITLE
Fix pushed fonts not being loaded due to CORS mode

### DIFF
--- a/Classes/Hooks/ContentPostProcessor.php
+++ b/Classes/Hooks/ContentPostProcessor.php
@@ -185,13 +185,13 @@ class ContentPostProcessor
                 return 'rel=preload; as=media';
                 break;
             case 'woff':
-                return 'rel=preload; as=font; type=font/woff';
+                return 'rel=preload; as=font; type=font/woff; crossorigin';
             case 'woff2':
-                return 'rel=preload; as=font; type=font/woff2';
+                return 'rel=preload; as=font; type=font/woff2; crossorigin';
             case 'eot':
-                return 'rel=preload; as=font; type=font/eot';
+                return 'rel=preload; as=font; type=font/eot; crossorigin';
             case 'ttf':
-                return 'rel=preload; as=font; type=font/ttf';
+                return 'rel=preload; as=font; type=font/ttf; crossorigin';
             default:
                 // Do not push the resource when conent type does not match.
                 return 'rel=preload; nopush';


### PR DESCRIPTION
Pushed fonts were ignored by the user agent and instead the fonts were requested again.

Chrome threw the following warning:
```
The resource path/to/some/font.woff was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it Please make sure it has an appropriate `as` value and it is preloaded intentionally.
```

See: https://github.com/w3c/preload/issues/32 and https://stackoverflow.com/a/46412740